### PR TITLE
add svg2jsx tool

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -1234,5 +1234,12 @@
     "url": "https://docsify.js.org/",
     "description": "Docsify easily generates your documentation website, built around your plain Markdown content and a theme, with minimal setup and configuration.",
     "tag": ["docs", "documentation", "utility", "markdown"]
+  },
+  {
+    "id": 137,
+    "title": "svg2jsx",
+    "url": "https://svg2jsx.com/",
+    "description": "This free tool allows you to paste normal SVG markup directly into the editor, and it outputs valid JSX code instantly, proper for use as a React component.",
+    "tag": ["utility", "tools", "online", "svg", "jsx", "converter", "react"]
   }
 ]


### PR DESCRIPTION
This PR adds the [svg2jsx tool](https://svg2jsx.com/) to the database, a simple online tool to transform SVG into valid JSX for use in React applications.