### PR TITLE
fix: add lazy loading to logo image

### DIFF
--- a/src/ui/molecules/card/index.jsx
+++ b/src/ui/molecules/card/index.jsx
@@ -4,7 +4,7 @@ export const Card = ({ result, children }) => {
   const { alt, description, logo, title, url } = result;
   return (
     <li className="card">
-      {logo && <img src={`${process.env.PUBLIC_URL}/logos/${logo}`} height="150" width="250" alt={alt || ""} />}
+      {logo && <img src={`${process.env.PUBLIC_URL}/logos/${logo}`} height="150" width="250" alt={alt || ""} loading="lazy" />}
       <h2>
         <a href={url}>{title}</a>
       </h2>


### PR DESCRIPTION
Quick one to add the browser lazy loading property https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading
Not sure if its needed as logos are pretty small in size.